### PR TITLE
Lombok

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,12 @@
             <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.20</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/ru/netology/domain/Radio.java
+++ b/src/main/java/ru/netology/domain/Radio.java
@@ -1,33 +1,16 @@
 package ru.netology.domain;
 
 public class Radio {
-    private int currentStation;
+    private int minVolume = 0;
+    private int maxVolume = 100;
     private int currentVolume;
 
-    public int getCurrentStation() {
-        return currentStation;
+    public int getMinVolume() {
+        return minVolume;
     }
 
-    public void setCurrentStation(int currentStation) {
-        if ((currentStation >= 0) && (currentStation <= 9)) {
-            this.currentStation = currentStation;
-        }
-    }
-
-    public void nextStation(){
-        if (currentStation == 9) {
-            currentStation = 0;
-            return;
-        }
-        currentStation++;
-    }
-
-    public void prevStation(){
-        if (currentStation == 0) {
-            currentStation = 9;
-            return;
-        }
-        currentStation--;
+    public int getMaxVolume() {
+        return maxVolume;
     }
 
     public int getCurrentVolume() {
@@ -35,21 +18,23 @@ public class Radio {
     }
 
     public void setCurrentVolume(int currentVolume) {
+        if ((currentVolume < this.getMinVolume()) || (currentVolume > this.getMaxVolume())) {
+            return;
+        }
         this.currentVolume = currentVolume;
     }
 
-    public void increaseVolume(){
-        if (currentVolume == 10) {
+    public void increaseVolume() {
+        if (currentVolume >= getMaxVolume()) {
             return;
         }
-        currentVolume++;
+        setCurrentVolume(++currentVolume);
     }
 
-    public void decreaseVolume(){
-        if (currentVolume == 0) {
+    public void decreaseVolume() {
+        if (currentVolume <= getMinVolume()) {
             return;
         }
-        currentVolume--;
+        setCurrentVolume(--currentVolume);
     }
-
 }

--- a/src/main/java/ru/netology/domain/Radio.java
+++ b/src/main/java/ru/netology/domain/Radio.java
@@ -1,5 +1,8 @@
 package ru.netology.domain;
 
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
 public class Radio {
     private int firstChannel = 0;
     private int countChannel = 10;
@@ -8,9 +11,6 @@ public class Radio {
     private int minVolume = 0;
     private int maxVolume = 100;
     private int currentVolume;
-
-    public Radio() {
-    }
 
     public Radio(int countChannel) {
         this.countChannel = countChannel;

--- a/src/main/java/ru/netology/domain/Radio.java
+++ b/src/main/java/ru/netology/domain/Radio.java
@@ -1,9 +1,60 @@
 package ru.netology.domain;
 
 public class Radio {
+    private int firstChannel = 0;
+    private int countChannel = 10;
+    private int lastChannel = 9;
+    private int currentChannel;
     private int minVolume = 0;
     private int maxVolume = 100;
     private int currentVolume;
+
+    public Radio() {
+    }
+
+    public Radio(int countChannel) {
+        this.countChannel = countChannel;
+        this.lastChannel = countChannel - 1;
+    }
+
+    public int getFirstChannel() {
+        return firstChannel;
+    }
+
+    public int getCountChannel() {
+        return countChannel;
+    }
+
+    public int getLastChannel() {
+        return lastChannel;
+    }
+
+    public int getCurrentChannel() {
+        return currentChannel;
+    }
+
+    public void setCurrentChannel(int currentChannel) {
+        if ((currentChannel < this.getFirstChannel()) || (currentChannel > this.getLastChannel())) {
+            return;
+        }
+        this.currentChannel = currentChannel;
+    }
+
+    public void nextChannel() {
+        if (currentChannel == getLastChannel()) {
+            currentChannel = getFirstChannel();
+            return;
+        }
+        setCurrentChannel(++currentChannel);
+    }
+
+    public void prevChannel() {
+        if (currentChannel == getFirstChannel()) {
+            currentChannel = getLastChannel();
+            return;
+        }
+        setCurrentChannel(--currentChannel);
+    }
 
     public int getMinVolume() {
         return minVolume;

--- a/src/test/java/ru/netology/domain/RadioTest.java
+++ b/src/test/java/ru/netology/domain/RadioTest.java
@@ -1,128 +1,58 @@
 package ru.netology.domain;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class RadioTest {
 
-    @Test
-    void shouldNotAcceptLessThenPossible() {
-        Radio service = new Radio();
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                    "shouldNotBeNegativeValue, -1, 0",
+                    "shouldBeEqualZero, 0, 0",
+                    "shouldBePositiveValue, 1, 1",
+                    "shouldBeLessThenMaxVolume, 99, 99",
+                    "shouldBeEqualMaxVolume, 100, 100",
+                    "shouldNotBeMoreThenMaxVolume, 101, 0"
+            }, delimiter = ',')
+    void shouldSetCurrentVolume(String testName, int currentVolume, int expected) {
+        Radio radio = new Radio();
 
-        int wrongStationNumber = -1;
-        service.setCurrentStation(wrongStationNumber);
+        radio.setCurrentVolume(currentVolume);
 
-        int expected = 0;
-
-        assertEquals(expected, service.getCurrentStation());
+        assertEquals(expected, radio.getCurrentVolume());
     }
 
-    @Test
-    void shouldNotAcceptMoreThenPossible() {
-        Radio service = new Radio();
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                    "shouldBeLessThenMaxVolume, 99, 100",
+                    "shouldNotBeMoreThenMaxVolume, 100, 100"
+            }, delimiter = ',')
+    void shouldIncreaseCurrentVolume(String testName, int currentVolume, int expected) {
+        Radio radio = new Radio();
 
-        int wrongStationNumber = 10;
-        service.setCurrentStation(wrongStationNumber);
+        radio.setCurrentVolume(currentVolume);
+        radio.increaseVolume();
 
-        int expected = 0;
-
-        assertEquals(expected, service.getCurrentStation());
+        assertEquals(expected, radio.getCurrentVolume());
     }
 
-    @Test
-    void shouldSelectNextStation() {
-        Radio service = new Radio();
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                    "shouldBeMoreThenMinVolume, 1, 0",
+                    "shouldNotBeLessThenMinVolume, 0, 0"
+            }, delimiter = ',')
+    void shouldDecreaseCurrentVolume(String testName, int currentVolume, int expected) {
+        Radio radio = new Radio();
 
-        service.setCurrentStation(8);
-        service.nextStation();
+        radio.setCurrentVolume(currentVolume);
+        radio.decreaseVolume();
 
-        int expected = 9;
-
-        assertEquals(expected, service.getCurrentStation());
+        assertEquals(expected, radio.getCurrentVolume());
     }
 
-    @Test
-    void shouldJumpToFirstStation() {
-        Radio service = new Radio();
-
-        service.setCurrentStation(9);
-        service.nextStation();
-
-        int expected = 0;
-
-        assertEquals(expected, service.getCurrentStation());
-    }
-
-    @Test
-    void shouldSelectPrevStation() {
-        Radio service = new Radio();
-
-        service.setCurrentStation(1);
-        service.prevStation();
-
-        int expected = 0;
-
-        assertEquals(expected, service.getCurrentStation());
-    }
-
-    @Test
-    void shouldJumpToLastStation() {
-        Radio service = new Radio();
-
-        service.setCurrentStation(0);
-        service.prevStation();
-
-        int expected = 9;
-
-        assertEquals(expected, service.getCurrentStation());
-    }
-
-    @Test
-    void shouldIncreaseVolume() {
-        Radio service = new Radio();
-
-        service.setCurrentVolume(5);
-        service.increaseVolume();
-
-        int expected = 6;
-
-        assertEquals(expected, service.getCurrentVolume());
-    }
-
-    @Test
-    void shouldNotIncreaseVolume() {
-        Radio service = new Radio();
-
-        service.setCurrentVolume(10);
-        service.increaseVolume();
-
-        int expected = 10;
-
-        assertEquals(expected, service.getCurrentVolume());
-    }
-
-    @Test
-    void shouldDecreaseVolume() {
-        Radio service = new Radio();
-
-        service.setCurrentVolume(5);
-        service.decreaseVolume();
-
-        int expected = 4;
-
-        assertEquals(expected, service.getCurrentVolume());
-    }
-
-    @Test
-    void shouldNotDecreaseVolume() {
-        Radio service = new Radio();
-
-        service.setCurrentVolume(0);
-        service.decreaseVolume();
-
-        int expected = 0;
-
-        assertEquals(expected, service.getCurrentVolume());
-    }
 }

--- a/src/test/java/ru/netology/domain/RadioTest.java
+++ b/src/test/java/ru/netology/domain/RadioTest.java
@@ -11,6 +11,103 @@ class RadioTest {
     @CsvSource(
             value = {
                     "shouldNotBeNegativeValue, -1, 0",
+                    "shouldBeEqualFirstChannel, 0, 0",
+                    "shouldBePositiveValue, 1, 1",
+                    "shouldBeLessThenLastChannel, 8, 8",
+                    "shouldBeEqualLastChannel, 9, 9",
+                    "shouldNotBeMoreThenMaxVolume, 10, 0"
+            }, delimiter = ',')
+    void shouldSetCurrentChannel(String testName, int currentChannel, int expected) {
+        Radio radio = new Radio();
+
+        radio.setCurrentChannel(currentChannel);
+
+        assertEquals(expected, radio.getCurrentChannel());
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                    "shouldIncreaseCurrentChannel, 8, 9",
+                    "shouldSetToFirstChannel, 9, 0"
+            }, delimiter = ',')
+    void shouldChangeNextStation(String testName, int currentChannel, int expected) {
+        Radio radio = new Radio();
+
+        radio.setCurrentChannel(currentChannel);
+        radio.nextChannel();
+
+        assertEquals(expected, radio.getCurrentChannel());
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                    "shouldDecreaseCurrentChannel, 1, 0",
+                    "shouldSetToFirstChannel, 0, 9"
+            }, delimiter = ',')
+    void shouldChangePrevStation(String testName, int currentChannel, int expected) {
+        Radio radio = new Radio();
+
+        radio.setCurrentChannel(currentChannel);
+        radio.prevChannel();
+
+        assertEquals(expected, radio.getCurrentChannel());
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                    "shouldNotBeNegativeValue, -1, 0",
+                    "shouldBeEqualFirstChannel, 0, 0",
+                    "shouldBePositiveValue, 1, 1",
+                    "shouldBeLessThenLastChannel, 98, 98",
+                    "shouldBeEqualLastChannel, 99, 99",
+                    "shouldNotBeMoreThenMaxVolume, 100, 0"
+            }, delimiter = ',')
+    void shouldSetCurrentChannelForCustomConstructor(String testName, int currentChannel, int expected) {
+        Radio radio = new Radio(100);
+
+        radio.setCurrentChannel(currentChannel);
+
+        assertEquals(expected, radio.getCurrentChannel());
+    }
+
+
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                    "shouldIncreaseCurrentChannel, 98, 99",
+                    "shouldSetToFirstChannel, 99, 0"
+            }, delimiter = ',')
+    void shouldChangeNextStationForCustomConstructor(String testName, int currentChannel, int expected) {
+        Radio radio = new Radio(100);
+
+        radio.setCurrentChannel(currentChannel);
+        radio.nextChannel();
+
+        assertEquals(expected, radio.getCurrentChannel());
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                    "shouldDecreaseCurrentChannel, 1, 0",
+                    "shouldSetToFirstChannel, 0, 99"
+            }, delimiter = ',')
+    void shouldChangePrevStationForCustomConstructor(String testName, int currentChannel, int expected) {
+        Radio radio = new Radio(100);
+
+        radio.setCurrentChannel(currentChannel);
+        radio.prevChannel();
+
+        assertEquals(expected, radio.getCurrentChannel());
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                    "shouldNotBeNegativeValue, -1, 0",
                     "shouldBeEqualZero, 0, 0",
                     "shouldBePositiveValue, 1, 1",
                     "shouldBeLessThenMaxVolume, 99, 99",


### PR DESCRIPTION
Using of @NoArgsConstructor doesn't cause decreasing of coverage level and creates necessary default constructor.
Using of @Data creates too much redundant getters, setters and other methods, which decrease coverage ratio to 0,44.